### PR TITLE
DNM: enable docker sanity 2.11 jobs and 2.11 network ee jobs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Bugfixes
 --------
 
 - Fix ansible.utils.cli_parse action plugin to support old cli_parse sub-plugin structure in ansible.netcommon collection.
+- Test sanity jobs for 2.11
 
 v2.0.0
 ======


### PR DESCRIPTION
depends-on: https://github.com/ansible/ansible-zuul-jobs/pull/833